### PR TITLE
Implement label events (enter, leave and click)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,4 +2,5 @@
 * [Options](options.md)
 * [Positioning](positioning.md)
 * [Formating](formatting.md)
+* [Events](events.md)
 * [Samples](https://chartjs-plugin-datalabels.netlify.com/samples)

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,67 @@
+# Events
+
+This plugin currently supports the following label events:
+
+| **Name** | **Chart events<sup>1</sup>** | **Description**
+| ---- | ---- | ----
+| `enter` | `mousemove` | the mouse is moved over a label
+| `leave` | `mousemove` | the mouse is moved out of an label
+| `click` | `click` | the mouse's primary button is pressed and released on a label
+
+> <sup>1</sup> [Chart.js events](http://www.chartjs.org/docs/latest/general/interactions/events.html) that need to be enabled in order to get the associated label event working. Note that by default Chart.js enables `"mousemove", "mouseout", "click", "touchstart", "touchmove", "touchend"`, meaning that label events work out-of-the-box.
+
+## Listeners
+
+The `listeners` option allows to register callbacks to be notified when an event is detected on a specific label. This option is an object where the property is the type of the event to listen and the value is a callback with a unique `context` argument.
+
+The `context` contains the same information as for [scriptable options](options.md#option-context), can be modified (e.g. add new properties) and thus, **if the callback explicitly returns `true`**, the label is updated with the new context and the chart re-rendered. This allows to implement visual interactions with labels such as highlight, selection, etc.
+
+Listeners can be registered for any label (`options.plugin.datalabels.listener.*`) or for labels of a specific dataset (`dataset.datalabels.listeners.*`).
+
+> **Tip:** if no listener is registered, incoming events are immediately ignored, preventing extra computation such as intersecting label bounding box. That means there should be no performance penalty for configurations that don't use events.
+
+## Example
+
+```javascript
+data: {
+  datasets: [{
+    datalabels: {
+      listeners: {
+        click: function(context) {
+          // Receives `click` events only for labels of the first dataset.
+          // The clicked label index is available in `context.dataIndex`.
+          console.log('label ' + context.dataIndex + ' has been clicked!');
+        }
+      }
+    }
+  }, {
+      //...
+  }]
+},
+options: {
+  plugins: {
+    datalabels: {
+      listeners: {
+        enter: function(context) {
+          // Receives `enter` events for any labels of any dataset. Indices of the
+          // clicked label are: `context.datasetIndex` and `context.dataIndex`.
+          // For example, we can modify keep track of the hovered state and
+          // return `true` to update the label and re-render the chart.
+          context.hovered = true;
+          return true;
+        },
+        leave: function(context) {
+          // Receives `leave` events for any labels of any dataset.
+          context.hovered = false;
+          return true;
+        }
+      },
+      color: function(context) {
+        // Change the label text color based on our new `hovered` context value.
+        return context.hovered ? "blue" : "gray";
+      }
+    }
+  }
+}
+```
+

--- a/docs/options.md
+++ b/docs/options.md
@@ -24,6 +24,7 @@ Available options:
 | `font.style` | `String` | - | - | [`defaultFontStyle`](http://www.chartjs.org/docs/latest/general/fonts.html)
 | `font.weight` | `String` | - | - | `'normal'`
 | `font.lineHeight` | `Number/String` | - | - | `1.2`
+| [`listeners`](events.md) | `Object` | - | - | `{}`
 | [`offset`](positioning.md#alignment-and-offset) | `Number` | Yes | Yes | `4`
 | `opacity` | `Number` | Yes | Yes | `1`
 | `padding` | `Number/Object` | Yes | Yes | -

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,7 +89,7 @@ gulp.task('docs', function(done) {
 	var cmd = process.execPath;
 
 	exec([cmd, script, 'install', './'].join(' ')).then(() => {
-		return exec([cmd, script, 'build', './', out].join(' '));
+		return exec([cmd, script, argv.watch ? 'serve' : 'build', './', out].join(' '));
 	}).then(() => {
 		done();
 	}).catch((err) => {

--- a/samples/events/highlight.html
+++ b/samples/events/highlight.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<link rel="stylesheet" type="text/css" href="../style.css">
+	<link rel="icon" type="image/ico" href="../favicon.ico">
+	<script src="https://cdn.jsdelivr.net/npm/chart.js@2.x/dist/Chart.min.js"></script>
+	<script src="../../dist/chartjs-plugin-datalabels.js"></script>
+	<script src="../utils.js"></script>
+</head>
+<body>
+	<div id="side">
+		<div id="header"></div>
+		<div id="actions">
+			<button onclick="randomize(this)">Randomize</button>
+			<button onclick="addData(this)">Add Data</button>
+			<button onclick="removeData(this)">Remove Data</button>
+		</div>
+	</div>
+
+	<div id="charts">
+		<div class="wrapper"><canvas id="chart-0"></canvas></div>
+	</div>
+
+	<script>
+		var SAMPLE_INFO = {
+			group: 'Events',
+			name: 'Highlight',
+			desc: 'Listen the <em>enter</em> and <em>leave</em> events to '
+				+ 'modify the label appearance when hovered by the mouse, '
+				+ 'using scriptable options.'
+		};
+	</script>
+
+	<script id="script-init">
+		var DATA_COUNT = 8;
+		var labels = [];
+
+		Samples.srand(0);
+
+		for (var i = 0; i < DATA_COUNT; ++i) {
+			labels.push('' + i);
+		}
+
+		Chart.helpers.merge(Chart.defaults.global, {
+			aspectRatio: 4/3,
+			tooltips: false,
+			layout: {
+				padding: {
+					top: 42,
+					right: 16,
+					bottom: 32,
+					left: 8
+				}
+			},
+			elements: {
+				line: {
+					fill: false
+				}
+			},
+			plugins: {
+				legend: false,
+				title: false
+			}
+		});
+	</script>
+
+	<script id="script-construct">
+		var chart = new Chart('chart-0', {
+			type: 'line',
+			data: {
+				labels: labels,
+				datasets: [{
+					backgroundColor: Samples.color(0),
+					borderColor: Samples.color(0),
+					data: Samples.numbers({
+						count: DATA_COUNT,
+						min: 0,
+						max: 100
+					}),
+					datalabels: {
+						align: 'start'
+					}
+				}, {
+					backgroundColor: Samples.color(1),
+					borderColor: Samples.color(1),
+					data: Samples.numbers({
+						count: DATA_COUNT,
+						min: 0,
+						max: 100
+					})
+				}, {
+					backgroundColor: Samples.color(2),
+					borderColor: Samples.color(2),
+					data: Samples.numbers({
+						count: DATA_COUNT,
+						min: 0,
+						max: 100
+					}),
+					datalabels: {
+						align: 'end'
+					}
+				}]
+			},
+			options: {
+				plugins: {
+					datalabels: {
+						backgroundColor: function(context) {
+							return context.hovered ? context.dataset.backgroundColor : 'white';
+						},
+						borderColor: function(context) {
+							return context.dataset.backgroundColor;
+						},
+						borderRadius: 16,
+						borderWidth: 1,
+						color: function(context) {
+							return context.hovered ? 'white' : context.dataset.backgroundColor;
+						},
+						font: {
+							weight: 'bold'
+						},
+						offset: 8,
+						formatter: Math.round,
+						listeners: {
+							enter: function(context) {
+								context.hovered = true;
+								return true;
+							},
+							leave: function(context) {
+								context.hovered = false;
+								return true;
+							}
+						}
+					}
+				},
+				scales: {
+					yAxes: [{
+						stacked: true
+					}]
+				}
+			}
+		});
+	</script>
+
+	<script id="script-actions">
+		function randomize() {
+			chart.data.datasets.forEach(function(dataset, i) {
+				dataset.backgroundColor = dataset.borderColor = Samples.color();
+				dataset.data = dataset.data.map(function(value) {
+					return Samples.rand(0, 100);
+				});
+			});
+
+			chart.update();
+		}
+
+		function addData() {
+			chart.data.labels.push(chart.data.labels.length);
+			chart.data.datasets.forEach(function(dataset, i) {
+				dataset.data.push(Samples.rand(0, 100));
+			});
+
+			chart.update();
+		}
+
+		function removeData() {
+			chart.data.labels.shift();
+			chart.data.datasets.forEach(function(dataset, i) {
+				dataset.data.shift();
+			});
+
+			chart.update();
+		}
+	</script>
+</body>
+</html>

--- a/samples/events/listeners.html
+++ b/samples/events/listeners.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<link rel="stylesheet" type="text/css" href="../style.css">
+	<link rel="icon" type="image/ico" href="../favicon.ico">
+	<script src="https://cdn.jsdelivr.net/npm/chart.js@2.x/dist/Chart.min.js"></script>
+	<script src="../../dist/chartjs-plugin-datalabels.js"></script>
+	<script src="../utils.js"></script>
+</head>
+<body>
+	<div id="side">
+		<div id="header"></div>
+		<code id="logs"></code>
+	</div>
+
+	<div id="charts">
+		<div class="wrapper"><canvas id="chart-0"></canvas></div>
+	</div>
+
+	<script>
+		var SAMPLE_INFO = {
+			group: 'Events',
+			name: 'Listeners'
+		};
+	</script>
+
+	<script id="script-init">
+		var DATA_COUNT = 6;
+		var labels = [];
+
+		Samples.srand(8);
+
+		for (var i = 0; i < DATA_COUNT; ++i) {
+			labels.push('' + i);
+		}
+
+		Chart.helpers.merge(Chart.defaults.global, {
+			aspectRatio: 4/3,
+			tooltips: false,
+			layout: {
+				padding: {
+					top: 42,
+					right: 16,
+					bottom: 32,
+					left: 8
+				}
+			},
+			elements: {
+				line: {
+					fill: false
+				}
+			},
+			plugins: {
+				legend: false,
+				title: false
+			}
+		});
+
+		function log(type, context) {
+			var line = document.createElement('div');
+			var logs = document.getElementById('logs');
+			var i = context.datasetIndex;
+			var j = context.dataIndex;
+			var v = context.dataset.data[j];
+
+			line.innerHTML = '> ' + type + ': ' + i + '-' + j + ' (' + v + ')';
+
+			logs.insertBefore(line, logs.firstChild);
+
+			if (logs.childNodes.length > 8) {
+				logs.removeChild(logs.lastChild);
+			}
+		}
+	</script>
+
+	<script id="script-construct">
+		var chart = new Chart('chart-0', {
+			type: 'line',
+			data: {
+				labels: labels,
+				datasets: [{
+					backgroundColor: Samples.color(0),
+					borderColor: Samples.color(0),
+					data: Samples.numbers({
+						count: DATA_COUNT,
+						min: 0,
+						max: 100
+					}),
+					datalabels: {
+						align: 'start'
+					}
+				}, {
+					backgroundColor: Samples.color(1),
+					borderColor: Samples.color(1),
+					data: Samples.numbers({
+						count: DATA_COUNT,
+						min: 0,
+						max: 100
+					})
+				}, {
+					backgroundColor: Samples.color(2),
+					borderColor: Samples.color(2),
+					data: Samples.numbers({
+						count: DATA_COUNT,
+						min: 0,
+						max: 100
+					}),
+					datalabels: {
+						align: 'end'
+					}
+				}]
+			},
+			options: {
+				plugins: {
+					datalabels: {
+						backgroundColor: function(context) {
+							return context.dataset.backgroundColor;
+						},
+						color: 'white',
+						font: {
+							weight: 'bold'
+						},
+						offset: 8,
+						padding: 4,
+						formatter: Math.round,
+						listeners: {
+							enter: function(context) {
+								log('enter', context);
+							},
+							leave: function(context) {
+								log('leave', context);
+							},
+							click: function(context) {
+								log('click', context);
+							}
+						}
+					}
+				},
+				scales: {
+					yAxes: [{
+						stacked: true
+					}]
+				}
+			}
+		});
+	</script>
+</body>
+</html>

--- a/samples/events/selection.html
+++ b/samples/events/selection.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<link rel="stylesheet" type="text/css" href="../style.css">
+	<link rel="icon" type="image/ico" href="../favicon.ico">
+	<script src="https://cdn.jsdelivr.net/npm/chart.js@2.x/dist/Chart.min.js"></script>
+	<script src="../../dist/chartjs-plugin-datalabels.js"></script>
+	<script src="../utils.js"></script>
+</head>
+<body>
+	<div id="side">
+		<div id="header"></div>
+		<code id="logs"></code>
+	</div>
+
+	<div id="charts">
+		<div class="wrapper"><canvas id="chart-0"></canvas></div>
+	</div>
+
+	<script>
+		var SAMPLE_INFO = {
+			group: 'Events',
+			name: 'Selection',
+			desc: 'Click events are handled to select labels, returning true to '
+				+ 're-render the chart and thus update the labels appearance.'
+		};
+	</script>
+
+	<script id="script-init">
+		var DATA_COUNT = 8;
+		var selection = [];
+		var labels = [];
+
+		Samples.srand(7);
+
+		for (var i = 0; i < DATA_COUNT; ++i) {
+			labels.push('' + i);
+		}
+
+		Chart.helpers.merge(Chart.defaults.global, {
+			aspectRatio: 4/3,
+			tooltips: false,
+			layout: {
+				padding: {
+					top: 42,
+					right: 16,
+					bottom: 32,
+					left: 8
+				}
+			},
+			elements: {
+				line: {
+					fill: false
+				}
+			},
+			plugins: {
+				legend: false,
+				title: false
+			}
+		});
+
+		function lookup(context) {
+			var dataset = context.datasetIndex;
+			var index = context.dataIndex;
+			var i, ilen;
+
+			for (i = 0, ilen = selection.length; i < ilen; ++i) {
+				if (selection[i].dataset === dataset && selection[i].index === index) {
+					return i;
+				}
+			}
+
+			return -1;
+		}
+
+		function isSelected(context) {
+			return lookup(context) !== -1;
+		}
+
+		function select(context) {
+			var dataset = context.datasetIndex;
+			var index = context.dataIndex;
+			var value = context.dataset.data[index];
+
+			selection.push({
+				dataset: dataset,
+				index: index,
+				value: value})
+
+			log(selection);
+		}
+
+		function deselect(context) {
+			var index = lookup(context);
+			if (index !== -1) {
+				selection.splice(index, 1);
+				log(selection);
+			}
+		}
+
+		function log(selection) {
+			var line = document.createElement('div');
+			var logs = document.getElementById('logs');
+
+			line.innerHTML = 'selection: ' + selection.map(function(item) {
+				return item.value;
+			}).join(', ');
+
+			logs.insertBefore(line, logs.firstChild);
+
+			if (logs.childNodes.length > 8) {
+				logs.removeChild(logs.lastChild);
+			}
+		}
+	</script>
+
+	<script id="script-construct">
+		var chart = new Chart('chart-0', {
+			type: 'line',
+			data: {
+				labels: labels,
+				datasets: [{
+					backgroundColor: Samples.color(0),
+					borderColor: Samples.color(0),
+					data: Samples.numbers({
+						count: DATA_COUNT,
+						decimals: 0,
+						min: 0,
+						max: 100
+					}),
+					datalabels: {
+						align: 'start'
+					}
+				}, {
+					backgroundColor: Samples.color(1),
+					borderColor: Samples.color(1),
+					data: Samples.numbers({
+						count: DATA_COUNT,
+						decimals: 0,
+						min: 0,
+						max: 100
+					})
+				}, {
+					backgroundColor: Samples.color(2),
+					borderColor: Samples.color(2),
+					data: Samples.numbers({
+						count: DATA_COUNT,
+						decimals: 0,
+						min: 0,
+						max: 100
+					}),
+					datalabels: {
+						align: 'end'
+					}
+				}]
+			},
+			options: {
+				plugins: {
+					datalabels: {
+						backgroundColor: function(context) {
+							return isSelected(context)
+								? context.dataset.backgroundColor
+								: 'white';
+						},
+						borderColor: function(context) {
+							return context.dataset.backgroundColor;
+						},
+						borderWidth: 1,
+						color: function(context) {
+							return isSelected(context)
+								? 'white'
+								: context.dataset.backgroundColor;
+						},
+						font: {
+							weight: 'bold'
+						},
+						offset: 8,
+						padding: 4,
+						listeners: {
+							click: function(context) {
+								if (isSelected(context)) {
+									deselect(context);
+								} else {
+									select(context);
+								}
+
+								return true;
+							}
+						}
+					}
+				},
+				scales: {
+					yAxes: [{
+						stacked: true
+					}]
+				}
+			}
+		});
+	</script>
+</body>
+</html>

--- a/samples/samples.js
+++ b/samples/samples.js
@@ -42,6 +42,18 @@
 			path: 'scriptable/mirror.html'
 		}]
 	}, {
+		title: 'Events',
+		items: [{
+			title: 'Listeners',
+			path: 'events/listeners.html'
+		}, {
+			title: 'Highlight',
+			path: 'events/highlight.html'
+		}, {
+			title: 'Selection',
+			path: 'events/selection.html'
+		}]
+	}, {
 		title: 'Formatting',
 		items: [{
 			title: 'Custom Labels',

--- a/samples/style.css
+++ b/samples/style.css
@@ -42,6 +42,8 @@ button:hover {
 	min-width: 240px;
 	max-width: 320px;
 	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
 	flex: 1;
 }
 
@@ -102,6 +104,26 @@ button:hover {
 	white-space: nowrap;
 }
 
+#logs {
+	display: flex;
+	flex-direction: column;
+	overflow-y: auto;
+	font-size: 0.7rem;
+	flex: 1 1 auto;
+}
+
+#logs > div {
+	border-bottom: 1px dashed #ddd;
+	padding: 0.5em 1em;
+}
+
+#logs > div:nth-child(n) { opacity: 0.2; }
+#logs > div:nth-child(5) { opacity: 0.4; }
+#logs > div:nth-child(4) { opacity: 0.6; }
+#logs > div:nth-child(3) { opacity: 0.8; }
+#logs > div:nth-child(2) { opacity: 1.0; }
+#logs > div:nth-child(1) { opacity: 1.0; font-weight: bold; }
+
 #charts {
 	min-width: 200px;
 	overflow-y: scroll;
@@ -136,5 +158,10 @@ button:hover {
 
 	#actions button {
 		margin: 0 2px 0 0;
+	}
+
+	#logs {
+		min-height: 15vh;
+		max-height: 15vh;
 	}
 }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -170,5 +170,22 @@ export default {
 			}
 		}
 		return '' + label;
-	}
+	},
+
+	/**
+	 * Event listeners, where the property is the type of the event to listen and the value
+	 * a callback with a unique `context` argument containing the same information as for
+	 * scriptable options. If a callback explicitly returns `true`, the label is updated
+	 * with the current context and the chart re-rendered. This allows to implement visual
+	 * interactions with labels such as highlight, selection, etc.
+	 *
+	 * Event currently supported are:
+	 * - 'click': a mouse click is detected within a label
+	 * - 'enter': the mouse enters a label
+	 * -' leave': the mouse leaves a label
+	 *
+	 * @member {Object}
+	 * @default {}
+	 */
+	listeners: {}
 };

--- a/src/hitbox.js
+++ b/src/hitbox.js
@@ -1,0 +1,53 @@
+'use strict';
+
+import Chart from 'chart.js';
+
+var helpers = Chart.helpers;
+
+var HitBox = function() {
+	this._rect = null;
+	this._rotation = 0;
+};
+
+helpers.extend(HitBox.prototype, {
+	update: function(center, rect, rotation) {
+		var margin = 1;
+		var cx = center.x;
+		var cy = center.y;
+		var x = cx + rect.x;
+		var y = cy + rect.y;
+
+		this._rotation = rotation;
+		this._rect = {
+			x0: x - margin,
+			y0: y - margin,
+			x1: x + rect.w + margin * 2,
+			y1: y + rect.h + margin * 2,
+			cx: cx,
+			cy: cy,
+		};
+	},
+
+	contains: function(x, y) {
+		var me = this;
+		var rect = me._rect;
+		var cx, cy, r, rx, ry;
+
+		if (!rect) {
+			return false;
+		}
+
+		cx = rect.cx;
+		cy = rect.cy;
+		r = me._rotation;
+		rx = cx + (x - cx) * Math.cos(r) + (y - cy) * Math.sin(r);
+		ry = cy - (x - cx) * Math.sin(r) + (y - cy) * Math.cos(r);
+
+		return !(rx < rect.x0
+			|| ry < rect.y0
+			|| rx > rect.x1
+			|| ry > rect.y1);
+	}
+});
+
+export default HitBox;

--- a/src/label.js
+++ b/src/label.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import Chart from 'chart.js';
+import HitBox from './hitbox';
 import utils from './utils';
 import positioners from './positioners';
 
@@ -169,6 +170,7 @@ function drawText(ctx, lines, rect, model) {
 var Label = function(config, ctx, el, index) {
 	var me = this;
 
+	me._hitbox = new HitBox();
 	me._config = config;
 	me._index = index;
 	me._model = null;
@@ -235,6 +237,7 @@ helpers.extend(Label.prototype, {
 
 		rects = boundingRects(model.size, model.padding);
 		center = coordinates(me._el, model, rects.frame);
+		me._hitbox.update(center, rects.frame, model.rotation);
 
 		ctx.save();
 		ctx.globalAlpha = utils.bound(0, model.opacity, 1);
@@ -245,6 +248,10 @@ helpers.extend(Label.prototype, {
 		drawText(ctx, model.lines, rects.text, model);
 
 		ctx.restore();
+	},
+
+	contains: function(x, y) {
+		return this._hitbox.contains(x, y);
 	}
 });
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -43,6 +43,94 @@ function drawLabels(chart, datasetIndex) {
 	}
 }
 
+function labelAtXY(chart, x, y) {
+	var items = chart[EXPANDO_KEY].labels;
+	var i, j, labels, label;
+
+	// Until we support z-index, let's hit test in the drawing reverse order
+	for (i = items.length - 1; i >= 0; --i) {
+		labels = items[i] || [];
+		for (j = labels.length - 1; j >= 0; --j) {
+			label = labels[j];
+			if (label.contains(x, y)) {
+				return {dataset: i, label: label};
+			}
+		}
+	}
+
+	return null;
+}
+
+function dispatchEvent(chart, listeners, target) {
+	var callback = listeners && listeners[target.dataset];
+	if (!callback) {
+		return;
+	}
+
+	var label = target.label;
+	var context = label.$context;
+
+	if (helpers.callback(callback, [context]) === true) {
+		// Users are allowed to tweak the given context by injecting values that can be
+		// used in scriptable options to display labels differently based on the current
+		// event (e.g. highlight an hovered label). That's why we update the label with
+		// the output context and schedule a new chart render by setting it dirty.
+		chart[EXPANDO_KEY].dirty = true;
+		label.update(context);
+	}
+}
+
+function dispatchMoveEvents(chart, listeners, previous, target) {
+	var enter, leave;
+
+	if (!previous && !target) {
+		return;
+	}
+
+	if (!previous) {
+		enter = true;
+	} else if (!target) {
+		leave = true;
+	} else if (previous.label !== target.label) {
+		leave = enter = true;
+	}
+
+	if (leave) {
+		dispatchEvent(chart, listeners.leave, previous);
+	}
+	if (enter) {
+		dispatchEvent(chart, listeners.enter, target);
+	}
+}
+
+function handleMoveEvents(chart, event) {
+	var expando = chart[EXPANDO_KEY];
+	var listeners = expando.listeners;
+	var previous, target;
+
+	if (!listeners.enter && !listeners.leave) {
+		return;
+	}
+
+	if (event.type === 'mousemove') {
+		target = labelAtXY(chart, event.x, event.y);
+	} else if (event.type !== 'mouseout') {
+		return;
+	}
+
+	previous = expando.hovered;
+	expando.hovered = target;
+	dispatchMoveEvents(chart, listeners, previous, target);
+}
+
+function handleClickEvents(chart, event) {
+	var handlers = chart[EXPANDO_KEY].listeners.click;
+	var target = handlers && labelAtXY(chart, event.x, event.y);
+	if (target) {
+		dispatchEvent(chart, handlers, target);
+	}
+}
+
 Chart.defaults.global.plugins.datalabels = defaults;
 
 Chart.plugins.register({
@@ -54,8 +142,18 @@ Chart.plugins.register({
 		};
 	},
 
+	beforeUpdate: function(chart) {
+		var expando = chart[EXPANDO_KEY];
+		expando.listened = false;
+		expando.listeners = {};    // {event-type: {dataset-index: function}}
+		expando.labels = [];       // [dataset-index: [labels]]
+	},
+
 	afterDatasetUpdate: function(chart, args, options) {
-		var dataset = chart.data.datasets[args.index];
+		var datasetIndex = args.index;
+		var expando = chart[EXPANDO_KEY];
+		var labels = expando.labels[datasetIndex] = [];
+		var dataset = chart.data.datasets[datasetIndex];
 		var config = configure(dataset, options);
 		var elements = args.meta.data || [];
 		var ilen = elements.length;
@@ -68,13 +166,13 @@ Chart.plugins.register({
 			el = elements[i];
 
 			if (el && !el.hidden && !el._model.skip) {
-				label = new Label(config, ctx, el, i);
+				labels.push(label = new Label(config, ctx, el, i));
 				label.update(label.$context = {
 					active: false,
 					chart: chart,
 					dataIndex: i,
 					dataset: dataset,
-					datasetIndex: args.index
+					datasetIndex: datasetIndex
 				});
 			} else {
 				label = null;
@@ -84,6 +182,16 @@ Chart.plugins.register({
 		}
 
 		ctx.restore();
+
+		// Store listeners at the chart level and per event type to optimize
+		// cases where no listeners are registered for a specific event
+		helpers.merge(expando.listeners, config.listeners || {}, {
+			merger: function(key, target, source) {
+				target[key] = target[key] || {};
+				target[key][args.index] = source[key];
+				expando.listened = true;
+			}
+		});
 	},
 
 	// Draw labels on top of all dataset elements
@@ -92,6 +200,24 @@ Chart.plugins.register({
 	afterDatasetsDraw: function(chart) {
 		for (var i = 0, ilen = chart.data.datasets.length; i < ilen; ++i) {
 			drawLabels(chart, i);
+		}
+	},
+
+	beforeEvent: function(chart, event) {
+		// If there is no listener registered for this chart, `listened` will be false,
+		// meaning we can immediately ignore the incoming event and avoid useless extra
+		// computation for users who don't implement label interactions.
+		if (chart[EXPANDO_KEY].listened) {
+			switch (event.type) {
+			case 'mousemove':
+			case 'mouseout':
+				handleMoveEvents(chart, event);
+				break;
+			case 'click':
+				handleClickEvents(chart, event);
+				break;
+			default:
+			}
 		}
 	},
 
@@ -111,8 +237,10 @@ Chart.plugins.register({
 			}
 		}
 
-		if (updates.length && !chart.animating) {
+		if ((expando.dirty || updates.length) && !chart.animating) {
 			chart.render();
 		}
+
+		delete expando.dirty;
 	}
 });

--- a/test/specs/events.spec.js
+++ b/test/specs/events.spec.js
@@ -1,0 +1,305 @@
+import Chart from 'chart.js';
+
+describe('events', function() {
+	beforeEach(function() {
+		this.data = {
+			labels: [1, 2, 3],
+			datasets: [{
+				data: [1, 2, 3]
+			}, {
+				data: [4, 5, 6]
+			}]
+		};
+	});
+
+	describe('`enter` handlers', function() {
+		it('should be called when the mouse moves inside the label', function() {
+			var spy = jasmine.createSpy('spy');
+			var chart = jasmine.chart.acquire({
+				type: 'line',
+				data: this.data,
+				options: {
+					plugins: {
+						datalabels: {
+							listeners: {
+								enter: spy
+							}
+						}
+					}
+				}
+			});
+
+			var ds0 = chart.getDatasetMeta(0);
+
+			expect(spy.calls.count()).toBe(0);
+
+			jasmine.triggerMouseEvent(chart, 'mousemove', ds0.data[1]);
+
+			expect(spy.calls.count()).toBe(1);
+
+			jasmine.triggerMouseEvent(chart, 'mousemove', ds0.data[2]);
+
+			expect(spy.calls.count()).toBe(2);
+			expect(spy.calls.argsFor(0)[0].dataIndex).toBe(1);
+			expect(spy.calls.argsFor(0)[0].datasetIndex).toBe(0);
+			expect(spy.calls.argsFor(1)[0].dataIndex).toBe(2);
+			expect(spy.calls.argsFor(1)[0].datasetIndex).toBe(0);
+		});
+	});
+
+	describe('`leave` handlers', function() {
+		it('should be called when the mouse moves outside the label', function() {
+			var spy = jasmine.createSpy('spy');
+			var chart = jasmine.chart.acquire({
+				type: 'line',
+				data: this.data,
+				options: {
+					plugins: {
+						datalabels: {
+							listeners: {
+								leave: spy
+							}
+						}
+					}
+				}
+			});
+
+			var ds0 = chart.getDatasetMeta(0);
+
+			expect(spy.calls.count()).toBe(0);
+
+			jasmine.triggerMouseEvent(chart, 'mousemove', ds0.data[1]);
+
+			expect(spy.calls.count()).toBe(0);
+
+			jasmine.triggerMouseEvent(chart, 'mousemove', ds0.data[2]);
+
+			expect(spy.calls.count()).toBe(1);
+			expect(spy.calls.argsFor(0)[0].dataIndex).toBe(1);
+			expect(spy.calls.argsFor(0)[0].datasetIndex).toBe(0);
+		});
+
+		it('should be called when the mouse moves out the canvas', function() {
+			var spy = jasmine.createSpy('spy');
+			var chart = jasmine.chart.acquire({
+				type: 'line',
+				data: this.data,
+				options: {
+					plugins: {
+						datalabels: {
+							listeners: {
+								leave: spy
+							}
+						}
+					}
+				}
+			});
+
+			var ds0 = chart.getDatasetMeta(0);
+
+			expect(spy.calls.count()).toBe(0);
+
+			jasmine.triggerMouseEvent(chart, 'mousemove', ds0.data[1]);
+
+			expect(spy.calls.count()).toBe(0);
+
+			jasmine.triggerMouseEvent(chart, 'mouseout');
+
+			expect(spy.calls.count()).toBe(1);
+			expect(spy.calls.argsFor(0)[0].dataIndex).toBe(1);
+			expect(spy.calls.argsFor(0)[0].datasetIndex).toBe(0);
+		});
+	});
+
+	describe('`click` handlers', function() {
+		it('should be called when user click a label', function() {
+			var spy = jasmine.createSpy('spy');
+			var chart = jasmine.chart.acquire({
+				type: 'line',
+				data: this.data,
+				options: {
+					plugins: {
+						datalabels: {
+							listeners: {
+								click: spy
+							}
+						}
+					}
+				}
+			});
+
+			var ds0 = chart.getDatasetMeta(0);
+
+			expect(spy.calls.count()).toBe(0);
+
+			jasmine.triggerMouseEvent(chart, 'click', ds0.data[1]);
+
+			expect(spy.calls.count()).toBe(1);
+			expect(spy.calls.argsFor(0)[0].dataIndex).toBe(1);
+			expect(spy.calls.argsFor(0)[0].datasetIndex).toBe(0);
+		});
+	});
+
+	describe('`listeners` option', function() {
+		it('should ignore events if empty', function() {
+			var chart = jasmine.chart.acquire({
+				type: 'line',
+				data: this.data
+			});
+
+			expect(chart.$datalabels.listened).toBeFalsy();
+		});
+
+		it('should call handlers for any labels if at the options level', function() {
+			var spy = jasmine.createSpy('spy');
+			var chart = jasmine.chart.acquire({
+				type: 'line',
+				data: this.data,
+				options: {
+					plugins: {
+						datalabels: {
+							listeners: {
+								click: spy
+							}
+						}
+					}
+				}
+			});
+
+			var ds0 = chart.getDatasetMeta(0);
+			var ds1 = chart.getDatasetMeta(1);
+
+			expect(chart.$datalabels.listened).toBeTruthy();
+			expect(spy.calls.count()).toBe(0);
+
+			jasmine.triggerMouseEvent(chart, 'click', ds0.data[1]);
+			jasmine.triggerMouseEvent(chart, 'click', ds1.data[2]);
+
+			expect(spy.calls.count()).toBe(2);
+			expect(spy.calls.argsFor(0)[0].dataIndex).toBe(1);
+			expect(spy.calls.argsFor(0)[0].datasetIndex).toBe(0);
+			expect(spy.calls.argsFor(1)[0].dataIndex).toBe(2);
+			expect(spy.calls.argsFor(1)[0].datasetIndex).toBe(1);
+		});
+
+		it('should call handlers only for labels of the same dataset if at the dataset level', function() {
+			var spy = jasmine.createSpy('spy');
+			var data = Chart.helpers.clone(this.data);
+
+			data.datasets[1].datalabels = {
+				listeners: {
+					click: spy
+				}
+			};
+
+			var chart = jasmine.chart.acquire({
+				type: 'line',
+				data: data
+			});
+
+			var ds0 = chart.getDatasetMeta(0);
+			var ds1 = chart.getDatasetMeta(1);
+
+			expect(chart.$datalabels.listened).toBeTruthy();
+			expect(spy.calls.count()).toBe(0);
+
+			jasmine.triggerMouseEvent(chart, 'click', ds0.data[1]);
+			jasmine.triggerMouseEvent(chart, 'click', ds1.data[2]);
+
+			expect(spy.calls.count()).toBe(1);
+			expect(spy.calls.argsFor(0)[0].dataIndex).toBe(2);
+			expect(spy.calls.argsFor(0)[0].datasetIndex).toBe(1);
+		});
+	});
+
+	describe('handlers', function() {
+		it('should update label when explicitly returning `true`', function() {
+			var options = {
+				opacity: function(context) {
+					return context.foobar ? 1 : 0.5;
+				},
+				listeners: {
+					click: function(context) {
+						context.foobar = !context.foobar;
+						return true;
+					}
+				}
+			};
+
+			spyOn(options, 'opacity');
+
+			var chart = jasmine.chart.acquire({
+				type: 'line',
+				data: this.data,
+				options: {
+					hover: false,
+					plugins: {
+						datalabels: options
+					}
+				}
+			});
+
+			spyOn(chart, 'render');
+
+			var ds0 = chart.getDatasetMeta(0);
+
+			expect(chart.render).not.toHaveBeenCalled();
+			expect(options.opacity).toHaveBeenCalled();
+			expect(options.opacity.calls.argsFor(0)[0].foobar).toBeUndefined();
+
+			options.opacity.calls.reset();
+			jasmine.triggerMouseEvent(chart, 'click', ds0.data[1]);
+
+			expect(chart.render).toHaveBeenCalled();
+			expect(options.opacity).toHaveBeenCalled();
+			expect(options.opacity.calls.argsFor(0)[0].foobar).toBeTruthy();
+
+			options.opacity.calls.reset();
+			jasmine.triggerMouseEvent(chart, 'click', ds0.data[1]);
+
+			expect(chart.render).toHaveBeenCalled();
+			expect(options.opacity).toHaveBeenCalled();
+			expect(options.opacity.calls.argsFor(0)[0].foobar).toBeFalsy();
+		});
+
+		it('should not update label when returning not `true`', function() {
+			var options = {
+				opacity: function(context) {
+					return context.foobar ? 1 : 0.5;
+				},
+				listeners: {
+					click: function(context) {
+						context.foobar = !context.foobar;
+						// WE DO NOT RETURN TRUE // return true;
+					}
+				}
+			};
+
+			spyOn(options, 'opacity');
+
+			var chart = jasmine.chart.acquire({
+				type: 'line',
+				data: this.data,
+				options: {
+					hover: false,
+					plugins: {
+						datalabels: options
+					}
+				}
+			});
+
+			spyOn(chart, 'render');
+
+			var ds0 = chart.getDatasetMeta(0);
+
+			expect(chart.render).not.toHaveBeenCalled();
+			expect(options.opacity).toHaveBeenCalled();
+
+			options.opacity.calls.reset();
+			jasmine.triggerMouseEvent(chart, 'click', ds0.data[1]);
+
+			expect(chart.render).not.toHaveBeenCalled();
+			expect(options.opacity).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
Add a new `listeners` option (object), where the property is the type of the event to listen and the value a callback with a unique `context` argument containing the same information as for scriptable options. If a callback explicitly returns `true`, the label is updated with the modified context and the chart re-rendered. This allows to implement visual interactions with labels such as highlight, selection, etc.

Note that there should be no performance penalty for configuration that don't use events since if there is no listener registered, we immediately ignore the incoming event and avoid useless extra computation.

[Documentation](https://deploy-preview-40--chartjs-plugin-datalabels.netlify.com/events.html) & samples: [listeners](https://deploy-preview-40--chartjs-plugin-datalabels.netlify.com/samples/events/listeners.html), [highlight](https://deploy-preview-40--chartjs-plugin-datalabels.netlify.com/samples/events/highlight.html), [selection](https://deploy-preview-40--chartjs-plugin-datalabels.netlify.com/samples/events/selection.html)

Fixes #17
