### PR TITLE
Fixed: Cannot read property '$context' of null

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -234,8 +234,8 @@ Chart.plugins.register({
 				label = update[0][EXPANDO_KEY];
 				if (label && label.$context) {
 					label.$context.active = (update[1] === 1);
-					label.update(label.$context);   
-			    	}
+					label.update(label.$context);
+				}
 			}
 		}
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -232,8 +232,10 @@ Chart.plugins.register({
 			update = updates[i];
 			if (update[1]) {
 				label = update[0][EXPANDO_KEY];
-				label.$context.active = (update[1] === 1);
-				label.update(label.$context);
+				if (label && label.$context) {
+					label.$context.active = (update[1] === 1);
+					label.update(label.$context);   
+			    	}
 			}
 		}
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -232,7 +232,7 @@ Chart.plugins.register({
 			update = updates[i];
 			if (update[1]) {
 				label = update[0][EXPANDO_KEY];
-				if (label && label.$context) {
+				if (label) {
 					label.$context.active = (update[1] === 1);
 					label.update(label.$context);
 				}


### PR DESCRIPTION
Since there is a possibility to get `label` as `null` (https://github.com/chartjs/chartjs-plugin-datalabels/blob/master/src/plugin.js#L178) it should be also filtered out from updating.