### PR TITLE
Fix hover interaction animations

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -98,6 +98,27 @@ function handleClickEvents(chart, event) {
 	}
 }
 
+// https://github.com/chartjs/chartjs-plugin-datalabels/issues/108
+function invalidate(chart) {
+	if (chart.animating) {
+		return;
+	}
+
+	// `chart.animating` can be `false` even if there is animation in progress,
+	// so let's iterate all animations to find if there is one for the `chart`.
+	var animations = Chart.animationService.animations;
+	for (var i = 0, ilen = animations.length; i < ilen; ++i) {
+		if (animations[i].chart === chart) {
+			return;
+		}
+	}
+
+	// No render scheduled: trigger a "lazy" render that can be canceled in case
+	// of hover interactions. The 1ms duration is a workaround to make sure an
+	// animation is created so the controller can stop it before any transition.
+	chart.render({duration: 1, lazy: true});
+}
+
 Chart.defaults.global.plugins.datalabels = defaults;
 
 var plugin = {
@@ -214,9 +235,7 @@ var plugin = {
 
 		if (expando._dirty || updates.length) {
 			layout.update(expando._labels);
-			if (!chart.animating) {
-				chart.render();
-			}
+			invalidate(chart);
 		}
 
 		delete expando._dirty;


### PR DESCRIPTION
Flag the render request as "lazy" so the controller can cancel it in order to correctly animate hover interactions. The 1ms duration is a workaround to make sure an animation is created so the controller can stop it before any transition. Also, verify if there is an "active" animation, in which case we don't need to explicitly call render().

@dutrieux @rpearce can you verify if these changes fix your issues?

@nagix what do you think about that workaround?

Fixes #108 