### PR TITLE
Fix declare module Chart

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,8 +1,9 @@
 import { Options } from './options';
+import { Chart } from 'chart.js';
 
 export * from './context';
 
-declare module 'chart.js' {
+declare module Chart {
 	interface ChartDataSets {
 		/**
 		 * Per dataset datalabels plugin options.


### PR DESCRIPTION
In the declaration of the Chart module to access the datalabels interfaces, it was being created in the wrong way, which was causing problems when executing the code after installing this api.

I corrected the statement and made the amount correctly.