### PR TITLE
Improve development experience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2415,9 +2415,9 @@
       "dev": true
     },
     "@types/cors": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.9.tgz",
-      "integrity": "sha512-zurD1ibz21BRlAOIKP8yhrxlqKx6L9VCwkB5kMiP6nZAhoF5MvC7qS1qPA7nRcr1GJolfkQC7/EAL4hdYejLtg==",
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz",
+      "integrity": "sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==",
       "dev": true
     },
     "@types/estree": {
@@ -5009,21 +5009,21 @@
       }
     },
     "chartjs-test-utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/chartjs-test-utils/-/chartjs-test-utils-0.2.0.tgz",
-      "integrity": "sha512-lEL5XEdIgwscr9JmCKSVHtfZLDo+HSsqvX07LzFouzN29x/XuZ+8H1ZhLu1xcMj6sG4G/eI/W1v4bt1xm5R0OQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/chartjs-test-utils/-/chartjs-test-utils-0.2.2.tgz",
+      "integrity": "sha512-WJ9zhoBzhsLHsskPW8YFiLBbdOZ7aPOcsvr7aGVuDwbbyyAJWj2gz0osdTcBTjuGiEPYuXcf+S6UNV4zEjo3gQ==",
       "dev": true,
       "requires": {
         "jasmine": "^3.6.4",
-        "karma": "^6.1.0",
+        "karma": "^6.1.1",
         "karma-jasmine": "^4.0.1",
         "pixelmatch": "^5.2.1"
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.14.25",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-          "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==",
+          "version": "14.14.31",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
           "dev": true
         },
         "ansi-regex": {
@@ -5170,9 +5170,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.5",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.5.tgz",
-          "integrity": "sha512-kBBSQbz2K0Nyn+31j/w36fUfxkBW9/gfwRWdUY1ULReH3iokVJgddZAFcD1D0xlgTmFxJCbUkUclAlc6/IDJkw==",
+          "version": "4.2.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
           "dev": true
         },
         "is-binary-path": {
@@ -5206,9 +5206,9 @@
           "dev": true
         },
         "karma": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/karma/-/karma-6.1.0.tgz",
-          "integrity": "sha512-QmRZ6HdKe6mHd89Az6yb85URRyDbXmn2IBo3lic7cwkkLjDWpjrMJxPAKlwNa5dFM1iHdT+kjtNJM0J5YAH90A==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/karma/-/karma-6.1.1.tgz",
+          "integrity": "sha512-vVDFxFGAsclgmFjZA/qGw5xqWdZIWxVD7xLyCukYUYd5xs/uGzYbXGOT5zOruVBQleKEmXIr4H2hzGCTn+M9Cg==",
           "dev": true,
           "requires": {
             "body-parser": "^1.19.0",
@@ -5344,9 +5344,9 @@
           }
         },
         "ua-parser-js": {
-          "version": "0.7.23",
-          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
-          "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
+          "version": "0.7.24",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
+          "integrity": "sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==",
           "dev": true
         },
         "ws": {
@@ -17023,9 +17023,9 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "version": "20.2.6",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
+      "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==",
       "dev": true
     },
     "yeast": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint . --ext .js --ext .ts",
     "package": "node scripts/create-packages.js",
     "test-unit": "karma start --single-run --coverage --grep",
-    "test-unit:dev": "karma start --grep",
+    "test-unit:dev": "karma start --auto-watch --grep",
     "test-types": "tsc -p types/test",
     "test": "npm run test-types && npm run test-unit",
     "test:dev": "npm run test-unit:dev"
@@ -42,7 +42,7 @@
     "acorn": "^8.0.4",
     "archiver": "^5.1.0",
     "chart.js": "~2.9.4",
-    "chartjs-test-utils": "^0.2.0",
+    "chartjs-test-utils": "^0.2.2",
     "eslint": "^7.15.0",
     "eslint-config-chartjs": "^0.3.0",
     "eslint-plugin-es": "^3.0.1",


### PR DESCRIPTION
* Update chartjs-test-utils to latest version
  *  Adds textual output of fixture diffs in log
* Add --auto-watch switch to karma when run with `npm run test:dev`, so the non-minified build gets used. Easier to debug.