### PR TITLE
Adds type property to label context

### DIFF
--- a/docs/guide/options.md
+++ b/docs/guide/options.md
@@ -66,6 +66,7 @@ The context object contains the following properties:
 | Property | Type | Description
 | -------- | ---- | -----------
 | `active` | `bool` | Whether the associated element is hovered ([see interactions](http://www.chartjs.org/docs/latest/general/interactions/)).
+| `type` | `string` | The type of context, always `datalabels`.
 | `chart` | `Chart` | The associated chart.
 | `dataIndex` | `number` | The index of the associated data.
 | `dataset` | `object` | The dataset at index `datasetIndex`.

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -189,6 +189,7 @@ export default {
             _key: key || DEFAULT_KEY
           };
           label.$context = {
+            type: 'datalabels',
             active: false,
             chart: chart,
             dataIndex: i,

--- a/test/specs/options.spec.js
+++ b/test/specs/options.spec.js
@@ -48,6 +48,7 @@ describe('options', function() {
         ].forEach(function(e, i) {
           expect(options[key].calls.argsFor(i)[0]).toEqual({
             active: false,
+            type: 'datalabels',
             chart: chart,
             dataIndex: e.dataIndex,
             dataset: chart.data.datasets[e.datasetIndex],

--- a/types/context.d.ts
+++ b/types/context.d.ts
@@ -13,6 +13,12 @@ export interface Context {
   active: boolean;
 
   /**
+   * The type of teh context, 'datalabels'.
+   * @since 2.0.0
+   */
+  type: string;
+  
+  /**
    * The associated chart.
    * @since 0.1.0
    */

--- a/types/context.d.ts
+++ b/types/context.d.ts
@@ -13,7 +13,7 @@ export interface Context {
   active: boolean;
 
   /**
-   * The type of teh context, 'datalabels'.
+   * The type of the context, 'datalabels'.
    * @since 2.0.0
    */
   type: string;

--- a/types/context.d.ts
+++ b/types/context.d.ts
@@ -17,7 +17,7 @@ export interface Context {
    * @since 2.0.0
    */
   type: string;
-  
+
   /**
    * The associated chart.
    * @since 0.1.0

--- a/types/test/exports.ts
+++ b/types/test/exports.ts
@@ -20,6 +20,7 @@ const chart = new Chart('id', {
 // Scriptable context
 const ctx: Context = {
   active: true,
+  type: 'datalabels',
   chart: chart,
   datasetIndex: 0,
   dataIndex: 0,


### PR DESCRIPTION
As reported in CHART.JS issue https://github.com/chartjs/Chart.js/issues/8623 and the related PR https://github.com/chartjs/Chart.js/pull/8626, there is the following new guideline about context:

> **Note:** the `context` argument should be validated in the scriptable function, because the function can be invoked in different contexts. The `type` field is a good candidate for this validation.

This PR is adding `type` property to label context.