### PR TITLE
Correct plugin name for registration

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -67,7 +67,7 @@ Since version 1.x, this plugin **no longer registers itself automatically**. It 
 
 ```javascript
 // Register the plugin to all charts:
-Chart.plugins.register(ChartDataLabels);
+Chart.plugins.register('chartjs-plugin-annotation');
 ```
 
 ```javascript


### PR DESCRIPTION
I was only able to use the plugin with the name `'chartjs-plugin-annotation'` instead of `ChartDataLabels`.