### PR TITLE
Remove install command for chart.js types

### DIFF
--- a/docs/guide/typescript.md
+++ b/docs/guide/typescript.md
@@ -2,10 +2,6 @@
 
 This plugin provides TypeScript type declaration files bundled in the npm package so that types of this plugin options are checked when building your TypeScript project.
 
-```sh
-npm install --save-dev @types/chart.js
-```
-
 ## Option Context
 
 The declaration of the [option context](options.md#option-context) is exported as `Context`:


### PR DESCRIPTION
Since `@types/chart.js` provides typing for v2 and chart.js and datalabels both come with build in typing these lines to install the types are unessasarry and will only give more confusing when it doesnt work